### PR TITLE
feat: use Geist font

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # React + TypeScript + Vite
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
-This project uses the [Geist](https://fonts.google.com/specimen/Geist) font for its interface.
+This project uses the [Geist](https://fonts.google.com/specimen/Geist) and [Geist Mono](https://fonts.google.com/specimen/Geist+Mono) fonts for its interface.
 
 Currently, two official plugins are available:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # React + TypeScript + Vite
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This project uses the [Geist](https://fonts.google.com/specimen/Geist) font for its interface.
 
 Currently, two official plugins are available:
 

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Geist:wght@100;200;300;400;500;600;700;800;900&display=swap"
       rel="stylesheet" />
 
     <!-- Microsoft Clarity Tracking -->

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Geist:wght@100;200;300;400;500;600;700;800;900&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Geist+Mono:wght@100;200;300;400;500;600;700;800;900&family=Geist:wght@100;200;300;400;500;600;700;800;900&display=swap"
       rel="stylesheet" />
 
     <!-- Microsoft Clarity Tracking -->

--- a/src/components/case-study.tsx
+++ b/src/components/case-study.tsx
@@ -17,7 +17,7 @@ const CaseStudy = () => {
 
   return (
     <AnimatedSection id="case-studies" className="space-y-12">
-      <h2 className="text-2xl font-bold text-dark">Case Studies</h2>
+      <h2 className="text-2xl font-light uppercase text-dark">/Case Studies</h2>
       <div className="grid grid-cols-1 gap-12 sm:grid-cols-2 lg:grid-cols-1">
         {caseStudiesData.map(({ image, title, slug, description, tags, externalLink }, index) => (
           <AnimatedSection

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -4,15 +4,20 @@ import { socialLinks } from "@/data";
 
 export const Hero = () => {
   return (
-    <AnimatedSection id="#" className="flex flex-col items-center font-body md:flex-row md:py-16">
-      <div className="mb-16 mt-28 flex flex-col md:mb-0 md:w-full">
-        <h1 className="leading-20 font-title text-5xl font-medium sm:text-6xl">Hi, I&apos;m Thushara.</h1>
-        <p className="my-8 font-title text-3xl leading-10">
-          I design intuitive digital experiences that bring simplicity, clarity, and ease to users while aligning with business goals.
+    <AnimatedSection id="#" className="flex flex-col items-center py-28 text-center font-body">
+      <div className="flex max-w-3xl flex-col items-center gap-8">
+        <h1 className="font-mono text-5xl font-bold leading-20 sm:text-6xl">Hi, I&apos;m Thushara.</h1>
+        <p className="text-xl font-bold leading-10">
+          I design intuitive interfaces that bring simplicity and clarity, with psychology, research, and strategy guiding every decision to move users and metrics.
         </p>
-        <a href={socialLinks.find(({ label }) => label === "Email")?.link}>
-          <Button variant="outline">Work with me</Button>
-        </a>
+        <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+          <a href="/resume.pdf" target="_blank" rel="noreferrer">
+            <Button variant="outline">Resume</Button>
+          </a>
+          <a href={socialLinks.find(({ label }) => label === "Email")?.link}>
+            <Button variant="outline">Hire me</Button>
+          </a>
+        </div>
       </div>
     </AnimatedSection>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,3 @@
-/* @import url("https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap"); */
-/* @import url("https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap"); */
-/* @import url("https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&family=Nunito:ital,wght@0,200..1000;1,200..1000&display=swap"); */
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,9 +3,9 @@ const config = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ["Nunito", "sans-serif"],
-        body: ["Nunito", "sans-serif"],
-        title: ["Instrument Serif", "serif"],
+        sans: ["Geist", "sans-serif"],
+        body: ["Geist", "sans-serif"],
+        title: ["Geist", "sans-serif"],
       },
       borderRadius: {
         "4xl": "1.875rem",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,7 @@ const config = {
         sans: ["Geist", "sans-serif"],
         body: ["Geist", "sans-serif"],
         title: ["Geist", "sans-serif"],
+        mono: ["Geist Mono", "monospace"],
       },
       borderRadius: {
         "4xl": "1.875rem",


### PR DESCRIPTION
## Summary
- load Geist from Google Fonts
- apply Geist as default sans/body/title font in Tailwind
- document use of Geist in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type @typescript-eslint/no-explicit-any)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac961c289c832faf2aa7b7a4c722a9